### PR TITLE
バックスラッシュでルール検出をスキップできるように

### DIFF
--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -62,6 +62,21 @@ describe("Parser", () => {
 		])
 	})
 
+	const bottlemail = "@linkagecommunity/bottlemail"
+	it(`"${bottlemail}" must be parsed as Text`, () => {
+		expect(parse(bottlemail)).toEqual([
+			{ kind: TextKind, value: bottlemail, raw: bottlemail }
+		])
+	})
+
+	const cancelMention = "\\@linkage"
+	it(`"${cancelMention}" must be parsed as Text`, () => {
+		console.dir(cancelMention)
+		expect(parse(cancelMention)).toEqual([
+			{ kind: TextKind, value: cancelMention, raw: cancelMention }
+		])
+	})
+
 	const nonURLStartsWithHTTP = "httpisgod"
 	it(`parse "${nonURLStartsWithHTTP}" as Text`, () => {
 		expect(parse(nonURLStartsWithHTTP)).toEqual([

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -71,7 +71,6 @@ describe("Parser", () => {
 
 	const cancelMention = "\\@linkage"
 	it(`"${cancelMention}" must be parsed as Text`, () => {
-		console.dir(cancelMention)
 		expect(parse(cancelMention)).toEqual([
 			{ kind: TextKind, value: cancelMention, raw: cancelMention }
 		])

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -126,6 +126,11 @@ function* parse(source: string) {
 
 		/** Dig kind */
 		if (whitespace.includes(char)) continue
+		if ("\\" === char) {
+			// skip next charactor
+			i++
+			continue
+		}
 		rule =
 			rules.find(({ startsWith }): boolean => {
 				return startsWith.some(expected => {


### PR DESCRIPTION
`\@dolphin` でメンションされなくなる